### PR TITLE
Fix concurrency error

### DIFF
--- a/Sources/OSInfo/OS.swift
+++ b/Sources/OSInfo/OS.swift
@@ -9,7 +9,7 @@ import Foundation
 #endif
 
 /// A unified, cross-platform API to  determine OS name and version on which the app is running
-public struct OS {
+public struct OS: Sendable {
     // MARK: public variables
 
     /// Singleton that will return the underlying macOS version / name for a running Mac Catalyst / Mac Designed for iPad application


### PR DESCRIPTION
- Fix concurrency error in Swift 6
  - Add Sendable

> [!CAUTION]
>  Static property 'current' is not concurrency-safe because non-'Sendable' type 'OS' may have shared mutable state

```swift
public static let current = OS(underlyingMacOS: true) // Static property 'current' is not concurrency-safe because non-'Sendable' type 'OS' may have shared mutable state
```